### PR TITLE
Specify Fly app in CI deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@v1
       - name: Deploy to Fly.io
-        run: flyctl deploy --image ghcr.io/${{ github.repository }}:${{ github.sha }} --remote-only
+        run: flyctl deploy --app ${{ secrets.FLY_APP_NAME }} --image ghcr.io/${{ github.repository }}:${{ github.sha }} --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       - name: Smoke test


### PR DESCRIPTION
## Summary
- pass the Fly.io app name via `FLY_APP_NAME` secret during deployment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890a8e23c7c8325abcbaddc77a7e7eb